### PR TITLE
Disable cache for tile requests

### DIFF
--- a/src/containers/imageview.jsx
+++ b/src/containers/imageview.jsx
@@ -52,7 +52,7 @@ class ImageView extends Component {
 			maxLevel: img.maxLevel,
 			height: img.height,
 			width: img.width,
-			minLevel: 0,
+      minLevel: 0,
     }
   }
 
@@ -150,7 +150,10 @@ class ImageView extends Component {
       compositeOperation: "lighter",
       prefixUrl: "images/openseadragon/",
       tileSources: this.makeTileSources(ids),
-      maxZoomPixelRatio: 10
+      maxZoomPixelRatio: 10,
+      ajaxHeaders: {
+        "Cache-Control": "no-store"
+      }
     });
     interactor(this.viewer);
 

--- a/src/containers/minervaimageview.jsx
+++ b/src/containers/minervaimageview.jsx
@@ -105,7 +105,10 @@ class MinervaImageView extends Component {
       // Specific to this project
       id: "ImageView",
       prefixUrl: "images/openseadragon/",
-      maxZoomPixelRatio: 10
+      maxZoomPixelRatio: 10,
+      ajaxHeaders: {
+        "Cache-Control": "no-store"
+      }
     });
     interactor(this.viewer);
 

--- a/src/containers/simpleimageview.jsx
+++ b/src/containers/simpleimageview.jsx
@@ -87,7 +87,10 @@ class MinervaImageView extends Component {
       // Specific to this project
       id: "ImageView",
       prefixUrl: "images/openseadragon/",
-      maxZoomPixelRatio: 10
+      maxZoomPixelRatio: 10,
+      ajaxHeaders: {
+        "Cache-Control": "no-store"
+      }
     });
     interactor(this.viewer);
 


### PR DESCRIPTION
Browser caching creates issues when switching to another image, the old images' tiles get loaded from the cache.
Since we're loading tiles from localhost, it probably makes sense to just disable caching altogether.