### PR TITLE
Example solution for creating an opacity slider

### DIFF
--- a/src/containers/controls.jsx
+++ b/src/containers/controls.jsx
@@ -110,6 +110,7 @@ class Controls extends Component {
   render() {
 
     const {addArrowText, rgba, minerva} = this.props;
+    const {maskOpacity, handleOpacityChange} = this.props;
     const {deleteOverlay, deleteArrow, toggleTextTab} = this.props;
     const {activeStory, handleSelectStory} = this.props;
     const {handleSortStoryMasks, handleSelectStoryMasks} = this.props;
@@ -242,11 +243,7 @@ class Controls extends Component {
         />
       </div>
     ) : '';
-    let maskOpacity = 0.5;
-    let handleOpacityChange = (value) => {
-      // assign this value to mask Opacity
-      // TODO
-    };
+
     let maskData = minerva ? '' : (
       <div className="ui form">
           <div className="row">

--- a/src/containers/repo.jsx
+++ b/src/containers/repo.jsx
@@ -423,6 +423,7 @@ class Repo extends Component {
           label: v,
         }];
       })),
+      maskOpacity: 0.5,
       chanRender: defaultChanRender
     };
 
@@ -500,6 +501,7 @@ class Repo extends Component {
     this.labelRGBA = this.labelRGBA.bind(this);
     this.defaultStory = this.defaultStory.bind(this);
     this.handleUpdateAllMasks = this.handleUpdateAllMasks.bind(this);
+    this.handleOpacityChange = this.handleOpacityChange.bind(this);
     this.handleUpdateMask = this.handleUpdateMask.bind(this);
     this.handleMaskChange = this.handleMaskChange.bind(this);
     this.handleMaskInsert = this.handleMaskInsert.bind(this);
@@ -1060,6 +1062,11 @@ class Repo extends Component {
 
   handleUpdateAllMasks(newMask) {
     this.setState(handleUpdateAllMasksPure(this.state, newMask));
+  }
+
+  handleOpacityChange(value) {
+    // use setState to assign this value to maskOpacity
+    this.setState({maskOpacity: value});
   }
 
   handleUpdateMask(newMaskParams, clear=false) {
@@ -2937,6 +2944,8 @@ class Repo extends Component {
               isMaskMapLoading={this.state.isMaskMapLoading}
               invalidMaskMap={this.state.invalidMaskMap}
               toggleTextTab={this.toggleTextTab}
+              maskOpacity={this.state.maskOpacity}
+              handleOpacityChange={this.handleOpacityChange}
             />
             <Confirm
               header="Save file location"


### PR DESCRIPTION
These are the next steps for creating an input for opacity in minerva-author-ui. This is building off of https://github.com/nholland20/minerva-author-ui/pull/1, which provides the basic non-interactive UI for the slider. After this PR, several steps must still be taken to pass `this.state.maskOpacity` down to `ImageView` to actually reflect the opacity in the mask images.